### PR TITLE
feat(deque#rotate): Add rotate method to Immutable::Deque

### DIFF
--- a/lib/immutable/deque.rb
+++ b/lib/immutable/deque.rb
@@ -110,10 +110,32 @@ module Immutable
       @front.last # memoize?
     end
 
+    # Return a new `Deque` with `n` rotatations performed. Positive is right, negative is left, and 0 is no-op
+    #
+    # @example
+    #   Immutable::Deque["A", "B", "C"].rotate(1)
+    #   # => Immutable::Deque["C", "A", "B"]
+    #   Immutable::Deque["A", "B", "C"].rotate(-1)
+    #   # => Immutable::Deque["B", "C", "A"]
+    #
+    # @param n [Integer] number of rotations to perform
+    # @return [Deque]
+    def rotate(n)
+      return self.class.empty if self.empty?
+
+      if n < 0
+        self.shift.push(self.first).rotate(n + 1)
+      elsif n > 0
+        self.pop.unshift(self.last).rotate(n - 1)
+      else
+        self
+      end
+    end
+
     # Return a new `Deque` with `item` added at the end.
     #
     # @example
-    #   Immutable::Deque["A", "B", "C"].add("Z")
+    #   Immutable::Deque["A", "B", "C"].push("Z")
     #   # => Immutable::Deque["A", "B", "C", "Z"]
     #
     # @param item [Object] The item to add

--- a/spec/lib/immutable/deque/rotate_spec.rb
+++ b/spec/lib/immutable/deque/rotate_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe Immutable::Deque do
+  describe "#rotate" do
+    [
+      [[], 9999, []],
+      [['A'], -1, ['A']],
+      [['A', 'B', 'C'], -1, ['B', 'C', 'A']],
+      [['A', 'B', 'C', 'D'], 0, ['A', 'B', 'C', 'D']],
+      [%w[A B C D], 2, %w[C D A B]],
+    ].each do |values, rotation, expected|
+      context "on #{values.inspect}" do
+        let(:deque) { D[*values] }
+
+        it "preserves the original" do
+          deque.rotate(rotation)
+          deque.should eql(D[*values])
+        end
+
+        it "returns #{expected.inspect}" do
+          deque.rotate(rotation).should eql(D[*expected])
+        end
+
+        it "returns a frozen instance" do
+          deque.rotate(rotation).should be_frozen
+        end
+      end
+    end
+
+    context "on empty subclass" do
+      let(:subclass) { Class.new(Immutable::Deque) }
+      let(:empty_instance) { subclass.new }
+      it "returns an empty object of the same class" do
+        empty_instance.rotate(1).class.should be subclass
+        empty_instance.rotate(-1).class.should be subclass
+      end
+    end
+  end
+end


### PR DESCRIPTION
* brings in-line with modern Deque libs
* allow for more efficient rotation than Array#rotate
* adds rspec tests for new functionality