### PR TITLE
Remove require hash, to fix circular dependency

### DIFF
--- a/lib/immutable/list.rb
+++ b/lib/immutable/list.rb
@@ -4,7 +4,6 @@ require 'concurrent'
 
 require 'immutable/undefined'
 require 'immutable/enumerable'
-require 'immutable/hash'
 require 'immutable/set'
 
 module Immutable

--- a/lib/immutable/set.rb
+++ b/lib/immutable/set.rb
@@ -1,6 +1,5 @@
 require 'immutable/undefined'
 require 'immutable/enumerable'
-require 'immutable/hash'
 require 'immutable/trie'
 require 'immutable/sorted_set'
 require 'set'

--- a/lib/immutable/vector.rb
+++ b/lib/immutable/vector.rb
@@ -1,5 +1,4 @@
 require 'immutable/enumerable'
-require 'immutable/hash'
 
 module Immutable
 


### PR DESCRIPTION
Using `Immutable::Hash`, I got a warning about a circular dependency.

`/Users/sean/development/immutable-ruby/lib/immutable/vector.rb:2: warning: /Users/sean/development/immutable-ruby/lib/immutable/vector.rb:2: warning: loading in progress, circular require considered harmful - /Users/sean/development/immutable-ruby/lib/immutable/hash.rb`

It seems like this quick change fixes it and doesn't break any specs :)

